### PR TITLE
feat(p1): Phase 1 scaffold – locators-only

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,23 +1,6 @@
-# Utilitrack
-
-Phase 1 locator-only scaffold built with Vite, React, and Tailwind.
-
-## Setup
-
-```bash
-npm i
-npm run dev
-```
-
-Create `.env.local` with Firebase configuration:
-
-```
 VITE_FIREBASE_API_KEY=YOUR_KEY
 VITE_FIREBASE_AUTH_DOMAIN=YOUR_AUTH_DOMAIN
 VITE_FIREBASE_PROJECT_ID=YOUR_PROJECT_ID
 VITE_FIREBASE_STORAGE_BUCKET=YOUR_BUCKET
 VITE_FIREBASE_MESSAGING_SENDER_ID=YOUR_SENDER_ID
 VITE_FIREBASE_APP_ID=YOUR_APP_ID
-```
-
-Org ID is hardcoded to `utilitrack` during Phase 1.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,54 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+
+    function isOrgUser(orgId) {
+      return exists(/databases/$(db)/documents/orgs/$(orgId)/users/$(request.auth.uid));
+    }
+    function userDoc(orgId) {
+      return get(/databases/$(db)/documents/orgs/$(orgId)/users/$(request.auth.uid)).data;
+    }
+    function isAdmin(orgId) {
+      return isOrgUser(orgId) && ("admin" in userDoc(orgId).roles);
+    }
+    function canViewProject(orgId, projectId) {
+      return isAdmin(orgId) ||
+             (isOrgUser(orgId) && userDoc(orgId).assignments.projects.hasAny([projectId]));
+    }
+
+    match /orgs/{orgId} {
+      match /users/{uid} {
+        allow read: if request.auth != null && request.auth.uid == uid || isAdmin(orgId);
+        allow create, update, delete: if isAdmin(orgId);
+      }
+
+      match /config/{doc=**} {
+        allow read: if isOrgUser(orgId);
+        allow write: if isAdmin(orgId);
+      }
+
+      match /utilities/{utilityId} {
+        allow read: if isOrgUser(orgId);
+        allow write: if isAdmin(orgId);
+      }
+
+      match /projects/{projectId} {
+        allow read: if canViewProject(orgId, projectId);
+        allow write: if isAdmin(orgId);
+
+        match /segments/{segmentId} {
+          allow read: if canViewProject(orgId, projectId);
+
+          allow update: if canViewProject(orgId, projectId) && (
+            isAdmin(orgId) ||
+            (isOrgUser(orgId) && "locator" in userDoc(orgId).roles)
+          ) && request.resource.data.diff(resource.data).changedKeys().hasOnly([
+            "ticket","locate","conflicts","history","soil","notes"
+          ]);
+
+          allow create, delete: if isAdmin(orgId);
+        }
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Utilitrack</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "utilitrack",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint . --ext ts,tsx",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "firebase": "^10.12.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
+    "zustand": "^4.5.2",
+    "zod": "^3.22.4",
+    "maplibre-gl": "^3.6.2",
+    "shpjs": "^4.0.4",
+    "@tmcw/togeojson": "^4.5.0",
+    "jszip": "^3.10.1",
+    "date-fns": "^3.6.0",
+    "clsx": "^2.1.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "@types/maplibre-gl": "^2.1.10",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.3.3",
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,0 +1,21 @@
+import { BrowserRouter } from 'react-router-dom';
+import Nav from './Nav';
+import AppRouter from './router';
+import { AuthProvider } from '../features/auth/AuthProvider';
+import Toaster from './Toaster';
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <BrowserRouter>
+        <div className="min-h-screen flex flex-col">
+          <Nav />
+          <main className="flex-1 p-4">
+            <AppRouter />
+          </main>
+          <Toaster />
+        </div>
+      </BrowserRouter>
+    </AuthProvider>
+  );
+}

--- a/src/app/Loading.tsx
+++ b/src/app/Loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div className="p-4">Loading...</div>;
+}

--- a/src/app/Nav.tsx
+++ b/src/app/Nav.tsx
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '../features/auth/AuthProvider';
+
+export default function Nav() {
+  const { user, roles } = useAuth();
+  return (
+    <nav className="bg-gray-800 text-white p-4 flex gap-4">
+      <Link to="/" className="font-bold">Utilitrack</Link>
+      {user && <Link to="/">Dashboard</Link>}
+      {user && roles.includes('admin') && <Link to="/users">Users</Link>}
+      {user && roles.includes('admin') && <Link to="/config">Config</Link>}
+      {!user && <Link to="/login">Login</Link>}
+    </nav>
+  );
+}

--- a/src/app/Toaster.tsx
+++ b/src/app/Toaster.tsx
@@ -1,0 +1,7 @@
+export function toast(message: string) {
+  alert(message);
+}
+
+export default function Toaster() {
+  return null;
+}

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,20 @@
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Login from '../pages/Login';
+import Dashboard from '../pages/Dashboard';
+import Map from '../pages/Map';
+import Users from '../pages/Users';
+import Config from '../pages/Config';
+import RequireAuth from '../features/auth/RequireAuth';
+
+export default function AppRouter() {
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/" element={<RequireAuth><Dashboard /></RequireAuth>} />
+      <Route path="/project/:id" element={<RequireAuth><Map /></RequireAuth>} />
+      <Route path="/users" element={<RequireAuth role="admin"><Users /></RequireAuth>} />
+      <Route path="/config" element={<RequireAuth role="admin"><Config /></RequireAuth>} />
+      <Route path="*" element={<Navigate to="/" />} />
+    </Routes>
+  );
+}

--- a/src/features/auth/AuthProvider.tsx
+++ b/src/features/auth/AuthProvider.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { User, onAuthStateChanged } from 'firebase/auth';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { auth, firestore } from '../../lib/firebase';
+
+export type OrgRole = 'admin' | 'locator' | 'viewer';
+interface AuthContextValue {
+  user: User | null;
+  roles: OrgRole[];
+  loading: boolean;
+}
+const AuthContext = createContext<AuthContextValue>({ user: null, roles: [], loading: true });
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [roles, setRoles] = useState<OrgRole[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      if (!u) {
+        setRoles([]);
+        setLoading(false);
+        return;
+      }
+      const ref = doc(firestore, 'orgs', 'utilitrack', 'users', u.uid);
+      return onSnapshot(ref, (snap) => {
+        setRoles((snap.data()?.roles as OrgRole[]) || []);
+        setLoading(false);
+      });
+    });
+    return () => unsub();
+  }, []);
+
+  return <AuthContext.Provider value={{ user, roles, loading }}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/features/auth/RequireAuth.tsx
+++ b/src/features/auth/RequireAuth.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import Loading from '../../app/Loading';
+import { useAuth } from './AuthProvider';
+
+export default function RequireAuth({ children, role }: { children: ReactNode; role?: 'admin' }) {
+  const { user, roles, loading } = useAuth();
+  const location = useLocation();
+  if (loading) return <Loading />;
+  if (!user) return <Navigate to="/login" state={{ from: location }} replace />;
+  if (role && !roles.includes(role)) return <Navigate to="/" replace />;
+  return <>{children}</>;
+}

--- a/src/features/import/ImportWizard.tsx
+++ b/src/features/import/ImportWizard.tsx
@@ -1,0 +1,7 @@
+export default function ImportWizard() {
+  return (
+    <div>
+      <button className="bg-green-500 text-white p-2">Upload</button>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,0 +1,16 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const firestore = getFirestore(app);

--- a/src/lib/map.ts
+++ b/src/lib/map.ts
@@ -1,0 +1,28 @@
+import { Map } from 'maplibre-gl';
+import { Segment } from '../types/models';
+
+export function segmentsToFeatureCollection(segments: Segment[]) {
+  return {
+    type: 'FeatureCollection',
+    features: segments.map((s) => ({
+      type: 'Feature',
+      properties: { id: s.id, name: s.name },
+      geometry: s.geom,
+    })),
+  } as any;
+}
+
+export function addSegmentSource(map: Map, id: string, data: any) {
+  if (map.getSource(id)) map.removeSource(id);
+  map.addSource(id, { type: 'geojson', data });
+}
+
+export function addSegmentLayer(map: Map, id: string, source: string) {
+  if (map.getLayer(id)) map.removeLayer(id);
+  map.addLayer({
+    id,
+    type: 'line',
+    source,
+    paint: { 'line-color': '#f00', 'line-width': 2 },
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './app/App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { firestore } from '../lib/firebase';
+import { StateProfile, AppConfig } from '../types/models';
+
+export default function Config() {
+  const [profile, setProfile] = useState<StateProfile | null>(null);
+  const [config, setConfig] = useState<AppConfig | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const prof = await getDoc(doc(firestore, 'orgs/utilitrack/config/state'));
+      const cfg = await getDoc(doc(firestore, 'orgs/utilitrack/config/app'));
+      setProfile(prof.data() as StateProfile);
+      setConfig(cfg.data() as AppConfig);
+    };
+    load();
+  }, []);
+
+  const save = async () => {
+    if (profile) await setDoc(doc(firestore, 'orgs/utilitrack/config/state'), profile);
+    if (config) await setDoc(doc(firestore, 'orgs/utilitrack/config/app'), config);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Config</h1>
+      <div className="flex flex-col gap-2">
+        <input
+          type="number"
+          value={profile?.callAheadDays ?? ''}
+          onChange={(e) => setProfile({ ...(profile || {}), callAheadDays: Number(e.target.value) })}
+          placeholder="callAheadDays"
+          className="border p-2"
+        />
+        {/* More fields as needed */}
+        <button onClick={save} className="bg-blue-500 text-white p-2">Save</button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { firestore } from '../lib/firebase';
+import { Link } from 'react-router-dom';
+import { Project } from '../types/models';
+
+export default function Dashboard() {
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDocs(collection(firestore, 'orgs/utilitrack/projects'));
+      setProjects(snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) })));
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Projects</h1>
+      <ul className="list-disc ml-6">
+        {projects.map((p) => (
+          <li key={p.id}>
+            <Link to={`/project/${p.id}`} className="text-blue-500 underline">
+              {p.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="p-4 border">Tickets expiring soon (placeholder)</div>
+        <div className="p-4 border">Locate status counts (placeholder)</div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../lib/firebase';
+import { useAuth } from '../features/auth/AuthProvider';
+
+export default function Login() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  if (user) {
+    navigate('/');
+    return null;
+  }
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await signInWithEmailAndPassword(auth, email, password);
+    navigate('/');
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="p-4 flex flex-col gap-2 max-w-sm mx-auto">
+      <input
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="border p-2"
+      />
+      <input
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        type="password"
+        placeholder="Password"
+        className="border p-2"
+      />
+      <button className="bg-blue-500 text-white p-2">Login</button>
+    </form>
+  );
+}

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import maplibregl, { Map } from 'maplibre-gl';
+import { useParams } from 'react-router-dom';
+import { collection, doc, getDocs, updateDoc } from 'firebase/firestore';
+import { firestore } from '../lib/firebase';
+import { Segment } from '../types/models';
+import { useAuth } from '../features/auth/AuthProvider';
+import ImportWizard from '../features/import/ImportWizard';
+
+export default function MapPage() {
+  const { id } = useParams();
+  const { roles } = useAuth();
+  const [map, setMap] = useState<Map>();
+  const [segments, setSegments] = useState<Segment[]>([]);
+  const [selected, setSelected] = useState<Segment | null>(null);
+
+  useEffect(() => {
+    const m = new maplibregl.Map({
+      container: 'map',
+      style: 'https://demotiles.maplibre.org/style.json',
+      center: [-96, 37.8],
+      zoom: 3,
+    });
+    setMap(m);
+    return () => m.remove();
+  }, []);
+
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDocs(collection(firestore, `orgs/utilitrack/projects/${id}/segments`));
+      setSegments(snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) })));
+    };
+    load();
+  }, [id]);
+
+  const save = async () => {
+    if (!selected) return;
+    const ref = doc(firestore, `orgs/utilitrack/projects/${id}/segments`, selected.id);
+    await updateDoc(ref, selected as any);
+  };
+
+  return (
+    <div className="flex h-full">
+      <aside className="w-64 p-4 border-r">Sidebar (filters)</aside>
+      <div id="map" className="flex-1" />
+      {selected && (
+        <div className="w-64 p-4 border-l flex flex-col gap-2">
+          <input value={selected.ticket?.number || ''} placeholder="Ticket number" className="border p-1" />
+          <button onClick={save} className="bg-blue-500 text-white p-2">Save</button>
+        </div>
+      )}
+      {roles.includes('admin') && (
+        <div className="absolute top-4 right-4">
+          <ImportWizard />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { firestore } from '../lib/firebase';
+
+export default function Users() {
+  const [users, setUsers] = useState<any[]>([]);
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDocs(collection(firestore, 'orgs/utilitrack/users'));
+      setUsers(snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) })));
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Users</h1>
+      <button className="bg-blue-500 text-white p-2">Add user</button>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border p-2">Email</th>
+            <th className="border p-2">Roles</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.id}>
+              <td className="border p-2">{u.email}</td>
+              <td className="border p-2">{(u.roles || []).join(', ')}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface UIState {
+  sidebarOpen: boolean;
+  toggleSidebar: () => void;
+}
+
+export const useUIStore = create<UIState>((set) => ({
+  sidebarOpen: true,
+  toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
+}));

--- a/src/styles/utility.ts
+++ b/src/styles/utility.ts
@@ -1,0 +1,2 @@
+import { clsx } from 'clsx';
+export const classNames = (...classes: any[]) => clsx(...classes);

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+export const ProjectSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  city: z.string().optional(),
+  state: z.string().optional(),
+  createdAt: z.any(),
+  updatedAt: z.any(),
+});
+export type Project = z.infer<typeof ProjectSchema>;
+
+export const SegmentSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  geom: z.any(),
+  utilities: z.array(z.string()),
+  ticket: z
+    .object({
+      number: z.string().optional(),
+      description: z.string().optional(),
+      openedAt: z.any().optional(),
+      expiresAt: z.any().optional(),
+    })
+    .optional(),
+  locate: z.object({
+    status: z.enum(['pending_ticket', 'pending_locates', 'in_progress', 'completed']),
+    updatedAt: z.any().optional(),
+    updatedBy: z.string().optional(),
+  }),
+  conflicts: z
+    .object({
+      difficult: z.boolean().optional(),
+      access: z.boolean().optional(),
+      highProfile: z.boolean().optional(),
+      standby: z.boolean().optional(),
+      notes: z.string().optional(),
+    })
+    .optional(),
+  soil: z
+    .object({
+      dominant: z.string().optional(),
+      summary: z.record(z.number()).optional(),
+    })
+    .optional(),
+  history: z.array(z.object({ at: z.any(), by: z.string(), change: z.string() })),
+});
+export type Segment = z.infer<typeof SegmentSchema>;
+
+export const UserSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  displayName: z.string(),
+  roles: z.array(z.string()),
+  assignments: z.object({ projects: z.array(z.string()), utilities: z.array(z.string()) }),
+});
+export type User = z.infer<typeof UserSchema>;
+
+export const StateProfileSchema = z.object({
+  callAheadDays: z.number(),
+  ticketLifeDays: z.number(),
+  ruralMaxMiles: z.number(),
+  descriptionTemplate: z.string(),
+  positiveResponseCodes: z.array(z.string()),
+});
+export type StateProfile = z.infer<typeof StateProfileSchema>;
+
+export const AppConfigSchema = z.object({
+  soilTiles: z.string().optional(),
+  parcelTiles: z.string().optional(),
+  allowImport: z.boolean().optional(),
+});
+export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- bootstrap Vite + React + TS app with Tailwind setup
- add auth provider, routing, and placeholder pages (Login, Dashboard, Map, Users, Config)
- include Phase 1 Firestore security rules

## Testing
- `npm i` *(fails: 403 Forbidden for @tmcw/togeojson)*
- `npm run dev` *(fails: vite not found due to install failure)*


------
https://chatgpt.com/codex/tasks/task_e_689587dafae0832abbcf97742f8e4146